### PR TITLE
Little refactor to update the cart state in the Main component

### DIFF
--- a/src/components/Product/index.js
+++ b/src/components/Product/index.js
@@ -1,25 +1,16 @@
-import { useState } from 'react'
 import './styles.scss'
 
 const Product = (props) => {
   const {
     product,
     cart,
+    onAddToCart,
   } = props
-  const [cartItem, setCartItem] = useState(cart.getItem(product))
+  const cartItem = cart.getItem(product)
   const badgeText = cartItem ? `${cartItem.quantity} items in cart` : null
 
-  // NOTE: This is a HACK! Basically, we're forcing the component
-  // to re-render. We'll get this fixed later, when we use Context
-  // or Redux to manage the state.
-  // The issue here is that "cart" is an instance of Cart. When we call the
-  // "addItem()" method (even in the parent component), the cart object changes
-  // (i.e. cart.items[i].quantity increments), but the reference to the object
-  // remains the same, so React doesn't know that something changed.
-  const handleCartClick = () => {
-    setCartItem({
-      ...cart.addItem(product)
-    })
+  const handleAddToCart = () => {
+    onAddToCart(product)
   }
 
   return (
@@ -43,7 +34,7 @@ const Product = (props) => {
         <div className="actions mt-5 d-flex justify-content-between">
           <button
             className="add-to-cart btn btn-success btn-lg"
-            onClick={handleCartClick}
+            onClick={handleAddToCart}
           >Add to cart</button>
           <button className="add-to-cart btn btn-outline-primary btn-lg">View details</button>
         </div>

--- a/src/components/ProductList/index.js
+++ b/src/components/ProductList/index.js
@@ -5,6 +5,7 @@ const ProductList = (props) => {
   const {
     products,
     cart,
+    onAddToCart,
   } = props
 
   return (
@@ -15,6 +16,7 @@ const ProductList = (props) => {
             key={product.id}
             product={product}
             cart={cart}
+            onAddToCart={onAddToCart}
           />
         ))
       }

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -12,7 +12,7 @@ function App() {
   // TODO: Later, we'll use the Context to share the state.
   // And then, we'll switch to Redux to handle de application state.
   const [products, setProducts] = useState([])
-  const cart = new Cart()
+  const [cart, setCart] = useState(new Cart())
 
   useEffect(() => {
     async function fetchData() {
@@ -21,7 +21,11 @@ function App() {
     fetchData()
   }, [])
 
-  // TODO: pass the products through props for now
+  const handleAddToCart = product => {
+    cart.addItem(product)
+    setCart(Cart.clone(cart))
+  }
+
   return (
     <div className="main">
       <header className="header">
@@ -33,6 +37,7 @@ function App() {
         <ProductList
           products={products}
           cart={cart}
+          onAddToCart={handleAddToCart}
         />
       </section>
     </div>

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -23,7 +23,7 @@ function App() {
 
   const handleAddToCart = product => {
     cart.addItem(product)
-    setCart(Cart.clone(cart))
+    setCart(cart.clone())
   }
 
   return (

--- a/src/models/Cart/index.js
+++ b/src/models/Cart/index.js
@@ -31,8 +31,8 @@ class Cart {
     return this.items.find(item => item.id === product.id)
   }
 
-  static clone(cartInstance) {
-    return new Cart(cartInstance.items)
+  clone() {
+    return new Cart(this.items)
   }
 }
 

--- a/src/models/Cart/index.js
+++ b/src/models/Cart/index.js
@@ -1,6 +1,6 @@
 class Cart {
-  constructor() {
-    this.items = []
+  constructor(items) {
+    this.items = items || []
   }
 
   addItem(product) {
@@ -29,6 +29,10 @@ class Cart {
 
   getItem(product) {
     return this.items.find(item => item.id === product.id)
+  }
+
+  static clone(cartInstance) {
+    return new Cart(cartInstance.items)
   }
 }
 

--- a/src/models/Cart/index.test.js
+++ b/src/models/Cart/index.test.js
@@ -152,4 +152,21 @@ describe('Cart model', () => {
       expect(item).toBeUndefined()
     })
   })
+
+  describe('clone cart', () => {
+    it('clones a cart instance', () => {
+      const cart = new CartModel()
+      cart.addItem(products[0])
+
+      const clonedCart = cart.clone()
+
+      // First we ensure that clonedCart has
+      // the same CONTENT as original cart instance
+      expect(cart).toEqual(clonedCart)
+
+      // And then we check that the references are
+      // different, and hence they are different objects
+      expect(cart === clonedCart).toBeFalsy()
+    })
+  })
 })


### PR DESCRIPTION
Ahí hice unos cambios que me parecen interesantes para entender algunas cosas e ir evolucionando desde acá:

### El problema
Estábamos manejando estados en un componente visual que no debería saber nada de como cambiar el estado de algo que se deduce de lo que recibe por props. Incluso *la única responsablidad del componente \<Product\> en éste caso, es mostrar el producto y "avisar" que se apretó el botón de agregar al carrito*.

En éste caso el cart. Lo recibimos en una prop en el componente \<Product\> y dentro del mismo componente, manejamos el estado de `cartItem`. Si yo no hubiera hecho eso sin embargo, el carrito *se actualiza*, pero la vista no se re-renderiza. Por qué? Porque al cambiar atributos de un objeto determinado _*no modifica la referencia a ese objeto*_ entonces react no sabe que algo cambió.

### La solución propuesta
- Quitar el `useState`del componente \<Product\>, ya que no queremos que éste mantenga ningún estado.
- En lugar de cambiar el estado, directamente dejamos que el componente padre se encargue de manejar la acción de agregar un item al carrito, pasándole como parámetro el producto en cuestión.
- El padre (\<ProductList\>) llama directamente a su prop `onAddToCart()`
- El container, quien contiene a \<ProductList\> (\<Main\>) finalmente es quien se encargará (por ahora) de manejar el estado, llamando a `cart.addItem(product)`.

Hasta éste punto, si probamos éstos cambios, veremos que la vista no se re-renderiza y no se ven cambios cuando se hace click en cualquer botón de agregar al carrito, por lo que mencioné anteriormente: la instancia `cart` se modifica en su contenido (el atributo `items` tiene un elemento más), pero la referencia a esa instancia no cambia. Por lo tanto, necesitamos hacer dos cosas:

- Tener el cart como un estado, ya que el cambio de estado es el que provoca que el componente se re-renderice (si la referencia cambia obviamente)
- En mi caso, definir un método en el modelo del Cart para devolver un CLON de la instancia:

```javascript
clone(cart) {
  return new Cart(this.items)
}
```

además de modificar el constructor para que pueda recibir los items en caso de que existan.
Fíjense que el método retorna una NUEVA instancia de Cart (por lo tanto una nueva referencia).

- Luego en el container principal, handleo la acción de ésta manera:

```javascript
const handleAddToCart = product => {
    cart.addItem(product)
    setCart(cart.clone())
}
```
Vean que recién en éste punto defino qué quiere decir "agregar un item al carrito", haciendo `cart.addItem(product)`, y luego actualizo el estado con un clon del cart original.

De ésta forma los componentes visuales (que están dentro de `components/`) no resuelven ninguna lógica. **Solo se dedican a presentar visualmente el estado del modelo y notificar alguna acción del usuario**.

Sin embargo, estamos resolviendo algo de lógica en el container principal. Más adelante vamos a ver como se puede desacoplar el manejo del estado (que ahora usamos `useState()` en \<Main\>), de la presentación visual de ese estado.

### Improvements

La idea de éste cambio es entender las responsabilidades de cada componente. Pero como habrán notado, hay un par de cosas que podemos mejorar:

- Tenemos que pasar las props del cart desde el componente principal hasta el más simple, que lo necesita para saber qué mostrar en el badge. Esto puede resultar tedioso a medida que la app crece y más cosas dependen de la información del carrito.
- Lo mismo que antes, pero para la vuelta: el componente Product le tiene que avisar al componente ProductList que le tiene que avisar a su padre, que se agregó un item al carrito.

Pero bueno, creo que tenemos una linda base para ir haciendo modificaciones ;-)